### PR TITLE
[TLAP-1551] Bump node version to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: The Jabba version to install.
     default: "0.11.2"
 runs:
-  using: "node12"
+  using: "node16"
   main: "lib/main.js"
 branding:
   icon: "download"


### PR DESCRIPTION
Node 12 is deprecated so we need to update our actions to the node 16